### PR TITLE
update Jandex to 3.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,9 +119,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.1.8</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
I specifically chose Jandex 3.1 because Quarkus 3.8 is still on that version. Quarkus 3.15 is on Jandex 3.2, so that would also be an option, but the classes in this project are not very complex and no new features added in later Jandex versions would be useful.